### PR TITLE
Add "import" keyword and remove "rva" and "regexp"

### DIFF
--- a/grammars/yara.cson
+++ b/grammars/yara.cson
@@ -26,7 +26,7 @@
     ]
   }
   {
-    'match': '\\b(true|false|private|global|rule|strings|meta|condition|and|or|not|filesize|in|at|rva|of|for|all|any|nocase|regexp|fullword|wide|ascii|entrypoint|them|int8|int16|int32|uint8|uint16|uint32|include|matches|contains)\\b'
+    'match': '\\b(true|false|private|global|rule|strings|meta|condition|and|or|not|filesize|in|at|of|for|all|any|nocase|fullword|wide|ascii|entrypoint|them|int8|int16|int32|uint8|uint16|uint32|include|import|matches|contains)\\b'
     'name': 'keyword.yara'
   }
   {


### PR DESCRIPTION
The "import" keyword was introduced with YARA 3.0, "rva" was reserved but it won't be used, and "regexp" never existed as a keyword.
