### PR TITLE
Use explicit count modifiers

### DIFF
--- a/grammars/yara.cson
+++ b/grammars/yara.cson
@@ -75,7 +75,7 @@
   'string_escaped_char':
     'patterns': [
       {
-        'match': '\\\\(\\\\|[abefnprtv\'"?]|[0-3]\\d{,2}|[4-7]\\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})'
+        'match': '\\\\(\\\\|[abefnprtv\'"?]|[0-3]\\d{0,2}|[4-7]\\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})'
         'name': 'constant.character.escape.yara'
       }
       {


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by TextMate and Sublime Text). However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regular expressions.

This is causing a bug, reported at github/linguist#4300. You can [reproduce it in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fblacktop%2Flanguage-yara%2Fblob%2F1093d3d528dce6b3c8362dfedfce978cf9979b1e%2Fgrammars%2Fyara.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fviper-framework%2Fyara-rules%2Fblob%2F6a8a376542320c0c58ba15cd027653c76e05af4e%2Fleverage.yar&code=) and see [the fixed version](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2Flanguage-yara%2Fblob%2F4cca12bd1edd245d34fbe44a54d346bd932b11d9%2Fgrammars%2Fyara.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fviper-framework%2Fyara-rules%2Fblob%2F6a8a376542320c0c58ba15cd027653c76e05af4e%2Fleverage.yar&code=) as well.

/cc @wesinator 