### PR TITLE
Fix regex string termination with escaped slash

### DIFF
--- a/grammars/yara.cson
+++ b/grammars/yara.cson
@@ -66,6 +66,8 @@
     'name': 'string.regex.yara'
     'patterns': [
       {
+        'match': '\\\\.'
+        'name': 'constant.regex.escape.yara'
       }
     ]
   }


### PR DESCRIPTION
bug introduced in #7 caused regex with escaped slash `\/` to be split up.

example : https://github.com/ZirakZaheer/Senior-Year-Project/blob/6a51ac439ca2f5327407418c24d76cd743d44476/rules-master/email/urls.yar